### PR TITLE
Fix a bug when PATCH_MPU_REGION is set to 1

### DIFF
--- a/bootloader/source/card_patcher.c
+++ b/bootloader/source/card_patcher.c
@@ -454,7 +454,7 @@ u32 patchCardNdsArm9 (const tNDSHeader* ndsHeader, u32* cardEngineLocation, modu
 	
 	*((u32*)patches[7]) = cardPullOutOffset+4;
 	*((u32*)patches[8]) = cardReadCachedOffset;
-	*((u32*)patches[10]) = needFlushCache;
+	(u32*)patches[10] = needFlushCache;
 	
 	//copyLoop (oldArenaLow, cardReadPatch, 0xF0);	
 	

--- a/bootloader/source/card_patcher.c
+++ b/bootloader/source/card_patcher.c
@@ -454,7 +454,7 @@ u32 patchCardNdsArm9 (const tNDSHeader* ndsHeader, u32* cardEngineLocation, modu
 	
 	*((u32*)patches[7]) = cardPullOutOffset+4;
 	*((u32*)patches[8]) = cardReadCachedOffset;
-	(u32*)patches[10] = needFlushCache;
+	patches[10] = needFlushCache;
 	
 	//copyLoop (oldArenaLow, cardReadPatch, 0xF0);	
 	


### PR DESCRIPTION
The cache flush was not properly activated. This is needed for some games megaman zx that works with this change and  the following option : 
PATCH_MPU_REGION = 1
PATCH__MPU_SIZE = 3145728