### PR TITLE
Move fastCopy32 implementation from assembly to C

### DIFF
--- a/cardengine_arm7/source/cardEngine.c
+++ b/cardengine_arm7/source/cardEngine.c
@@ -319,6 +319,16 @@ bool cardRead (u32 dma,  u32 src, void *dst, u32 len) {
 	return true;
 }
 
+struct fc32_chunk {
+    u32 values[8];
+};
 
+void fastCopy32 (const struct fc32_chunk *src, struct fc32_chunk *dest, u32 len) {
+    do {
+        *dest = *src;
+
+        len -= sizeof(*dest);
+    } while (len > 0);
+}
 
 

--- a/cardengine_arm7/source/card_engine_header.s
+++ b/cardengine_arm7/source/card_engine_header.s
@@ -86,23 +86,6 @@ exit:
 
 .pool
 
-.global fastCopy32
-.type	fastCopy32 STT_FUNC
-@ r0 : src, r1 : dst, r2 : len
-fastCopy32:
-    stmfd   sp!, {r3-r11,lr}
-	@ copy 512 bytes
-	mov     r10, r0	
-	mov     r9, r1	
-	mov     r8, r2	
-loop_fastCopy32:
-	ldmia   r10!, {r0-r7}
-	stmia   r9!,  {r0-r7}
-	subs    r8, r8, #32  @ 4*8 bytes
-	bgt     loop_fastCopy32
-	ldmfd   sp!, {r3-r11,lr}
-    bx      lr
-
 card_engine_end:
 
 patches:

--- a/cardengine_arm9/source/cardEngine.c
+++ b/cardengine_arm9/source/cardEngine.c
@@ -229,6 +229,16 @@ void cardRead (u32* cacheStruct) {
 	}	
 }
 
+struct fc32_chunk {
+    u32 values[8];
+};
 
+void fastCopy32 (const struct fc32_chunk *src, struct fc32_chunk *dest, u32 len) {
+    do {
+        *dest = *src;
+
+        len -= sizeof(*dest);
+    } while (len > 0);
+}
 
 

--- a/cardengine_arm9/source/card_engine_header.s
+++ b/cardengine_arm9/source/card_engine_header.s
@@ -38,24 +38,6 @@ cacheStruct:
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 card_engine_start:
-
-.global fastCopy32
-.type	fastCopy32 STT_FUNC
-@ r0 : src, r1 : dst, r2 : len
-fastCopy32:
-    stmfd   sp!, {r3-r11,lr}
-	@ copy r2 bytes
-	mov     r10, r0	
-	mov     r9, r1	
-	mov     r8, r2	
-loop_fastCopy32:
-	ldmia   r10!, {r0-r7}
-	stmia   r9!,  {r0-r7}
-	subs    r8, r8, #32  @ 4*8 bytes
-	bgt     loop_fastCopy32
-	ldmfd   sp!, {r3-r11,lr}
-    bx      lr
-
 card_engine_end:
 
 .global readCachedRef


### PR DESCRIPTION
This should help with converting some of the card engine to
THUMB. It has been tested successfully with the European Bomberman
ROM.