### PR TITLE
Revert "Only use donor ROMs on ROMs below SDK v4"

### DIFF
--- a/bootloader/source/card_patcher.c
+++ b/bootloader/source/card_patcher.c
@@ -1079,15 +1079,13 @@ u32 patchCardNdsArm7 (const tNDSHeader* ndsHeader, u32* cardEngineLocation, modu
 	u32 saveResult = savePatchV1(ndsHeader, cardEngineLocation, moduleParams, saveFileCluster);
 	if(!saveResult) saveResult = savePatchV2(ndsHeader, cardEngineLocation, moduleParams, saveFileCluster);
 	if(!saveResult) {
-		if(moduleParams->sdk_version < 0x4027538) {
-			if ((donorFile.firstCluster >= CLUSTER_FIRST) && (donorFile.firstCluster < CLUSTER_EOF)) {			
-				dbg_printf("swap the arm7 binary");	
-				swapBinary_ARM7(donorFile);
-				// apply the arm7 binary swap and the save patch again, assume save v2 nds file
-				saveResult = savePatchV2(ndsHeader, cardEngineLocation, moduleParams, saveFileCluster);
-			} else {
-				dbg_printf("no arm7 binary specified for swapping");	
-			}
+		if ((donorFile.firstCluster >= CLUSTER_FIRST) && (donorFile.firstCluster < CLUSTER_EOF)) {			
+			dbg_printf("swap the arm7 binary");	
+			swapBinary_ARM7(donorFile);
+			// apply the arm7 binary swap and the save patch again, assume save v2 nds file
+			saveResult = savePatchV2(ndsHeader, cardEngineLocation, moduleParams, saveFileCluster);
+		} else {
+			dbg_printf("no arm7 binary specified for swapping");	
 		}
 	}
 	


### PR DESCRIPTION
Reverts ahezard/nds-bootstrap#81

Hate to say this, but this was a bad idea. :(
It broke support save support for Game & Watch Collection 1&2, which worked before, but no longer works, due to them needing save support.