### PR TITLE
Remove a redundant "return" statement

### DIFF
--- a/bootloader/source/card_patcher.c
+++ b/bootloader/source/card_patcher.c
@@ -156,7 +156,6 @@ module_params_t* findModuleParams(const tNDSHeader* ndsHeader, u32 donorSdkVer)
 				((module_params_t*)(moduleparams - 0x1C))->sdk_version = 0x5003001;
 				break;
 		}
-		return (module_params_t*)(moduleparams - 0x1C);
 	}
 	return (module_params_t*)(moduleparams - 0x1C);
 }


### PR DESCRIPTION
Also, all the code would need to be cleaned up, there are spaces at the end of lines, also there are mixed spaces and tabulations, and the writing style isn't consistent, sometimes there is: "varA==varB" and sometimes: "varA == varB", same thing for how are parameters given to functions