### PR TITLE
Fix implicit declarations in cardengine_arm7/source/cardEngine.c

### DIFF
--- a/cardengine_arm7/source/cardEngine.c
+++ b/cardengine_arm7/source/cardEngine.c
@@ -27,7 +27,9 @@
 #include "sr_data_error.h"	// For showing an error screen
 #include "sr_data_srloader.h"	// For rebooting into SRLoader
 
-extern void* memcpy(const void * src0, void * dst0, int len0);	// Fixes implicit declaration @ line 124 & 134
+extern void* memcpy(const void * src0, void * dst0, int len0);	// Fixes implicit declaration @ line 126 & 136
+extern int tryLockMutex(void);					// Fixes implicit declaration @ line 145
+extern int unlockMutex(void);					// Fixes implicit declaration @ line 223
 
 static bool initialized = false;
 static bool initializedIRQ = false;

--- a/cardengine_arm7/source/cardEngine.c
+++ b/cardengine_arm7/source/cardEngine.c
@@ -27,6 +27,8 @@
 #include "sr_data_error.h"	// For showing an error screen
 #include "sr_data_srloader.h"	// For rebooting into SRLoader
 
+extern void* memcpy(const void * src0, void * dst0, int len0);	// Fixes implicit declaration @ line 124 & 134
+
 static bool initialized = false;
 static bool initializedIRQ = false;
 static bool calledViaIPC = false;

--- a/cardengine_arm7/source/debugToFile.c
+++ b/cardengine_arm7/source/debugToFile.c
@@ -19,6 +19,8 @@
 #include <string.h>
 #include "fat.h"
 
+extern int nocashMessage(char [119]); // 119 because max is 120, starts at 0
+
 static bool _debug = false;
 static aFile _debugFileCluster;
 static u32 _currentPos = 0;


### PR DESCRIPTION
Fixes warning implicit declaration of memcpy, tryLockMutex and unlockMutex in cardengine_arm7/source/cardEngine.c

and implicit of nocashMessage in cardengine_arm7/source/debugToFile

Something simple that fixes a few compiler warnings. Nothing much, but I'm trying to help a project I like.