### PR TITLE
Travis: install all necessary DKP packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 install:
   - sudo dpkg -i pacman.deb
   - sudo dkp-pacman -Sy
-  - sudo dkp-pacman -S devkitARM libnds --noconfirm
+  - sudo dkp-pacman -S devkitARM general-tools dstools ndstool libnds libfat-nds --noconfirm
   - export DEVKITPRO=/opt/devkitpro
   - export DEVKITARM=${DEVKITPRO}/devkitARM
 


### PR DESCRIPTION
dkp-pacman does not include all the necessary tools with devkitARM.

nds-bootstrap requires the following:
* dkp-linux/devkitARM
* dkp-linux/general-tools
* dkp-linux/ndstool
* dkp-linux/dstools
* dkp-libs/libnds
* dkp-libs/libfat-nds