### PR TITLE
Fix the .ver file Travis makes and add a root makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,10 @@ install:
 script:
   - export COMMIT_TAG="$(git log --format=%h -1)"
   - export COMMIT_MESSAGE="$(git log --pretty=format:"%an - %s" -1)"
-  - cd retail/
-  - make nightly
+  - make package-nightly
   - mkdir bin/TWiLightMenu/
-  - echo $COMMIT_TAG >> bin/TWiLightMenu/nightly-bootstrap.ver
-  - cd ../hb/
-  - make nightly
-  - cd ../
-  - mkdir nds-bootstrap/
-  - mv retail/bin/* nds-bootstrap/
-  - mv hb/bin/* nds-bootstrap/
+  - printf $COMMIT_TAG >> bin/TWiLightMenu/nightly-bootstrap.ver
+  - mv bin/ nds-bootstrap/
   - 7z a nds-bootstrap.7z nds-bootstrap/
   
 addons:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+#---------------------------------------------------------------------------------
+# PACKAGE is the directory where final published files will be placed
+#---------------------------------------------------------------------------------
+PACKAGE		:=	bin
+
+#---------------------------------------------------------------------------------
+# Goals for Build
+#---------------------------------------------------------------------------------
+.PHONY: all package release nightly retail hb
+
+all:	retail hb
+
+package-release: release
+	@mkdir -p "$(PACKAGE)"
+	@cp "retail/bin/nds-bootstrap-release.nds" "$(PACKAGE)/nds-bootstrap-release.nds"
+	@cp "hb/bin/nds-bootstrap-hb-release.nds" "$(PACKAGE)/nds-bootstrap-hb-release.nds"
+
+package-nightly: nightly
+	@mkdir -p "$(PACKAGE)"
+	@cp "retail/bin/nds-bootstrap-nightly.nds" "$(PACKAGE)/nds-bootstrap-nightly.nds"
+	@cp "hb/bin/nds-bootstrap-hb-nightly.nds" "$(PACKAGE)/nds-bootstrap-hb-nightly.nds"
+
+release:
+	@$(MAKE) -C retail release
+	@$(MAKE) -C hb release
+
+nightly:
+	@$(MAKE) -C retail nightly
+	@$(MAKE) -C hb nightly
+
+retail:
+	@$(MAKE) -C retail
+
+hb:
+	@$(MAKE) -C hb
+
+clean:
+	@echo clean build direcotiries
+	@$(MAKE) -C retail clean
+	@$(MAKE) -C hb clean
+
+	@echo clean package files
+	@rm -rf "bin"


### PR DESCRIPTION
The `nightly-bootstrap.ver` that Travis was making had an extra line at the bottom, which caused: ![big 1](https://media.discordapp.net/attachments/489307733074640926/543054547027755008/IMG_20190207_140342.jpg?width=388&height=518)

This should fix that by switching from `echo` to `printf`, I also made a root makefile so that you don't have to build retail and hb separately.