### PR TITLE
Use correct commit sha in TWLBot commit (Hopefully)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,31 +20,32 @@ variables:
 
 steps:
 - script: |
-     curl -L https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb -o pacman.deb
-     sudo apt update
-     sudo apt install p7zip-full haveged
-     sudo dpkg -i pacman.deb
-     sudo dkp-pacman -Sy
-     sudo dkp-pacman -S nds-dev --noconfirm
+    curl -L https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb -o pacman.deb
+    sudo apt update
+    sudo apt install p7zip-full haveged
+    sudo dpkg -i pacman.deb
+    sudo dkp-pacman -Sy
+    sudo dkp-pacman -S nds-dev --noconfirm
   displayName: 'Setup devkitPro'
   
 - script: |
-     export DEVKITPRO="/opt/devkitpro"
-     export DEVKITARM="/opt/devkitpro/devkitARM"
-     make package-nightly
+    export DEVKITPRO="/opt/devkitpro"
+    export DEVKITARM="/opt/devkitpro/devkitARM"
+    make package-nightly
+
+    echo '##vso[task.setvariable variable=COMMIT_TAG]'$(git log --format=%h -1)
+    echo '##vso[task.setvariable variable=COMMIT_MESSAGE]'$(git log --pretty=format:"%an - %s" -1)
   displayName: 'Build nds-bootstrap'
 
 - script: |
-     mkdir bin/TWiLightMenu/
-     printf $(COMMIT_TAG) >> bin/TWiLightMenu/nightly-bootstrap.ver
-     mv bin/ nds-bootstrap/
-     7z a nds-bootstrap.7z nds-bootstrap/
-     cp nds-bootstrap.7z $(Build.ArtifactStagingDirectory)/nds-bootstrap.7z
+    mkdir bin/TWiLightMenu/
+    printf $(COMMIT_TAG) >> bin/TWiLightMenu/nightly-bootstrap.ver
+    mv bin/ nds-bootstrap/
+    7z a nds-bootstrap.7z nds-bootstrap/
+    cp nds-bootstrap.7z $(Build.ArtifactStagingDirectory)/nds-bootstrap.7z
   displayName: 'Pack 7z package'
 
 - script: |
-    echo '##vso[task.setvariable variable=COMMIT_TAG]'$(git log --format=%h -1)
-    echo '##vso[task.setvariable variable=COMMIT_MESSAGE]'$(git log --pretty=format:"%an - %s" -1)
     git config --global user.email "flamekat54@aol.com"
     git config --global user.name "TWLBot"
     git clone https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git


### PR DESCRIPTION
- This (should) make the TWLBot commits have the correct commit sha
  - This means I should be able to show commit notes in the Updater