### PR TITLE
Fix TWLCFG language setting

### DIFF
--- a/hb/bootloader/source/arm7/main.arm7.c
+++ b/hb/bootloader/source/arm7/main.arm7.c
@@ -233,7 +233,7 @@ static void resetMemory_ARM7 (void)
 		boot_readFirmware(settingsOffset + 0x100, (u8*)(NDS_HEADER-0x180), 0x70);
 	}
 
-	if ((*(u8*)0x02000400 & 0x0F) && (*(u8*)0x02000404 == 0) && language == -1) {
+	if ((*(u8*)0x02000400 & 0x0F) && (*(u8*)0x02000404 == 0) && (language == 0xFF || language == -1)) {
 		language = *(u8*)0x02000406;
 	}
 

--- a/retail/bootloader/source/arm7/main.arm7.c
+++ b/retail/bootloader/source/arm7/main.arm7.c
@@ -599,7 +599,7 @@ static void my_readUserSettings(tNDSHeader* ndsHeader) {
 
 	tonccpy(PersonalData, currentSettings, sizeof(PERSONAL_DATA));
 
-	if (useTwlCfg && language == -1) {
+	if (useTwlCfg && (language == 0xFF || language == -1)) {
 		language = twlCfgLang;
 	}
 


### PR DESCRIPTION
Now TWLCFG language setting will works fine when TWiLightMenu's guiLanguage or pergame language setting set to system and/or default.
Tested on KOR console.