### PR TITLE
Fix for issue #920

### DIFF
--- a/retail/bootloader/source/arm7/hook_arm7.c
+++ b/retail/bootloader/source/arm7/hook_arm7.c
@@ -114,10 +114,10 @@ int hookNdsRetailArm7(
 		}
 	}
 
-	if (!handlerLocation) {
+	if (handlerLocation) {
 		// Patch
-		//memcpy(handlerLocation, ce7->patches->j_irqHandler, 0xC);
-	//} else {
+		memcpy(handlerLocation, ce7->patches->j_irqHandler, 0xC);
+	} else {
 		dbg_printf("ERR_HOOK\n");
 		return ERR_HOOK;
 	}

--- a/retail/cardengine/arm7/source/card_engine_header.s
+++ b/retail/cardengine/arm7/source/card_engine_header.s
@@ -191,7 +191,7 @@ extraIrqTable:
 	.word	extraIrq_ret		@ Unused (0)
 	.word	extraIrq_ret		@ GPIO33[0] unknown (related to "GPIO330" testpoint on mainboard?)
 	.word	extraIrq_ret		@ GPIO33[1] Headphone connect (HP#SP) (static state)
-	.word	extraIrq_ret		@ GPIO33[2] Powerbutton interrupt (short pulse upon key-down)
+	.word	i2cIRQHandler		@ GPIO33[2] Powerbutton interrupt (short pulse upon key-down)
 	.word	extraIrq_ret		@ GPIO33[3] sound enable output (ie. not a useful irq-input)
 	.word	extraIrq_ret		@ SD/MMC Controller   ;-Onboard eMMC and External SD Slot
 	.word	extraIrq_ret		@ SD Slot Data1 pin   ;-For SDIO hardware in External SD Slot

--- a/retail/cardengine/arm7/source/cardengine.c
+++ b/retail/cardengine/arm7/source/cardengine.c
@@ -887,30 +887,6 @@ void myIrqHandlerVBlank(void) {
 		softResetTimer = 0;
 	}
 
-	int cause = (i2cReadRegister(I2C_PM, I2CREGPM_PWRIF) & 0x3) | (i2cReadRegister(I2C_GPIO, 0x02)<<2);
-
-	switch (cause & 3) {
-	case 1: {
-		if (saveTimer != 0) return;
-
-		REG_MASTER_VOLUME = 0;
-		int oldIME = enterCriticalSection();
-		if (consoleModel < 2) {
-			//unlaunchSetFilename(true);
-			sharedAddr[4] = 0x57534352;
-			IPC_SendSync(0x8);
-			waitFrames(5);							// Wait for DSi screens to stabilize
-		}
-		i2cWriteRegister(0x4A, 0x70, 0x01);
-		i2cWriteRegister(0x4A, 0x11, 0x01);			// Reboot console
-		leaveCriticalSection(oldIME);
-		break;
-	}
-	case 2:
-		writePowerManagement(PM_CONTROL_REG,PM_SYSTEM_PWR);
-		break;
-	}
-
 	if (consoleModel < 2 && (valueBits & preciseVolumeControl) && romRead_LED == 0 && dmaRomRead_LED == 0) {
 		// Precise volume adjustment (for DSi)
 		if (volumeAdjustActivated) {
@@ -960,6 +936,31 @@ void myIrqHandlerVBlank(void) {
 }
 
 void i2cIRQHandler(void) {
+	
+	int cause = (i2cReadRegister(I2C_PM, I2CREGPM_PWRIF) & 0x3) | (i2cReadRegister(I2C_GPIO, 0x02)<<2);
+
+	switch (cause & 3) {
+	case 1: {
+		if (saveTimer != 0) return;
+
+		REG_MASTER_VOLUME = 0;
+		int oldIME = enterCriticalSection();
+		if (consoleModel < 2) {
+			//unlaunchSetFilename(true);
+			sharedAddr[4] = 0x57534352;
+			IPC_SendSync(0x8);
+			waitFrames(5);							// Wait for DSi screens to stabilize
+		}
+		i2cWriteRegister(0x4A, 0x70, 0x01);
+		i2cWriteRegister(0x4A, 0x11, 0x01);			// Reboot console
+		leaveCriticalSection(oldIME);
+		break;
+	}
+	case 2:
+		writePowerManagement(PM_CONTROL_REG,PM_SYSTEM_PWR);
+		break;
+	}
+
 }
 
 u32 myIrqEnable(u32 irq) {	

--- a/retail/cardengine/arm7/source/cardengine.c
+++ b/retail/cardengine/arm7/source/cardengine.c
@@ -959,8 +959,8 @@ void myIrqHandlerVBlank(void) {
 	}
 }
 
-/*void i2cIRQHandler(void) {
-}*/
+void i2cIRQHandler(void) {
+}
 
 u32 myIrqEnable(u32 irq) {	
 	int oldIME = enterCriticalSection();	


### PR DESCRIPTION
This fixes the issue in Okamiden by moving some back out of the vblank irq handler an into the power button irq handler. This doesn't break the fix for the bug where changing the volume level crashes the game